### PR TITLE
Move backwards to a gaz revision that doesn't break factable tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v1.3.5"
 
 [[projects]]
-  digest = "1:93fc3c75986aeb31ce0974e8c3d1bde3458f9b284784894e963c260ed2c7560d"
+  digest = "1:4ac8f9d9e93a50d60647610b11acf438a8b06979120f1b5d5b683e78e927eddf"
   name = "github.com/LiveRamp/gazette"
   packages = [
     "v2/cmd/gazctl/editor",
@@ -56,7 +56,7 @@
     "v2/pkg/task",
   ]
   pruneopts = ""
-  revision = "c2f92d136744a7897be6a9e278c1da1b4e3c778c"
+  revision = "49c4ae6934cabaf52f21b5fc57bb7d6379c06ec5"
   source = "https://github.com/gazette/core"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,5 +23,5 @@
 # PS-1135
 [[constraint]]
   name = "github.com/LiveRamp/gazette"
-  revision = "c2f92d136744a7897be6a9e278c1da1b4e3c778c"
+  revision = "49c4ae6934cabaf52f21b5fc57bb7d6379c06ec5"
   source = "https://github.com/gazette/core"


### PR DESCRIPTION
Upon running `docker build` we realized that we pinned factable to a Gaz revision that breaks its tests. We are reverting to the specific Gaz revision that captures the bug fix we want while going no further than that.

```
Step 13/16 : RUN go install -tags rocksdb ${IMPORT_PATH}/cmd/...
 ---> Running in bec181bb58eb
# git.liveramp.net/jgraet/factable/cmd/examples/quotes-publisher
src/git.liveramp.net/jgraet/factable/cmd/examples/quotes-publisher/main.go:35:22: cfg.Broker.RoutedJournalClient undefined (type mainboilerplate.ClientConfig has no field or method RoutedJournalClient)
# git.liveramp.net/jgraet/factable/cmd/factctl
src/git.liveramp.net/jgraet/factable/cmd/factctl/backfill_load.go:29:28: cmd.cfg.Broker.RoutedJournalClient undefined (type mainboilerplate.ClientConfig has no field or method RoutedJournalClient)
src/git.liveramp.net/jgraet/factable/cmd/factctl/backfill_load.go:30:31: cmd.cfg.Extractor.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/backfill_specify.go:35:27: cmd.cfg.Broker.RoutedJournalClient undefined (type mainboilerplate.ClientConfig has no field or method RoutedJournalClient)
src/git.liveramp.net/jgraet/factable/cmd/factctl/backfill_specify.go:36:30: cmd.cfg.Extractor.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/query.go:27:29: cmd.cfg.VTable.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/schema_get.go:31:63: cmd.cfg.Extractor.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/schema_update.go:40:57: cmd.cfg.Extractor.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/sync.go:42:27: cmd.cfg.Broker.RoutedJournalClient undefined (type mainboilerplate.ClientConfig has no field or method RoutedJournalClient)
src/git.liveramp.net/jgraet/factable/cmd/factctl/sync.go:43:30: cmd.cfg.Extractor.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/sync.go:44:27: cmd.cfg.VTable.Dial undefined (type mainboilerplate.ClientConfig has no field or method Dial)
src/git.liveramp.net/jgraet/factable/cmd/factctl/sync.go:44:27: too many errors
The command '/bin/sh -c go install -tags rocksdb ${IMPORT_PATH}/cmd/...' returned a non-zero code: 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/factable/4)
<!-- Reviewable:end -->
