### PR TITLE
EOF fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/
+
+.idea

--- a/pkg/backfill/main.go
+++ b/pkg/backfill/main.go
@@ -5,6 +5,8 @@ import (
 	mbp "github.com/LiveRamp/gazette/v2/pkg/mainboilerplate"
 	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
 	"github.com/jessevdk/go-flags"
+
+	"git.liveramp.net/jgraet/factable/pkg/factable"
 )
 
 // JobSpec defines common specifications of a backfill job.

--- a/pkg/backfill/main.go
+++ b/pkg/backfill/main.go
@@ -5,8 +5,6 @@ import (
 	mbp "github.com/LiveRamp/gazette/v2/pkg/mainboilerplate"
 	pb "github.com/LiveRamp/gazette/v2/pkg/protocol"
 	"github.com/jessevdk/go-flags"
-
-	"git.liveramp.net/jgraet/factable/pkg/factable"
 )
 
 // JobSpec defines common specifications of a backfill job.

--- a/pkg/backfill/map.go
+++ b/pkg/backfill/map.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
+	"git.liveramp.net/jgraet/factable/pkg/factable"
+	"git.liveramp.net/jgraet/factable/pkg/internal"
 )
 
 type cmdMap struct {
@@ -82,7 +85,7 @@ func decode(mt MapTaskSpec, schema factable.Schema, out chan<- message.Envelope)
 
 	var br = bufio.NewReaderSize(fr, 32*1024)
 	for {
-		if b, err := framing.Unpack(br); err == io.EOF {
+		if b, err := framing.Unpack(br); errors.Cause(err) == io.EOF {
 			return nil
 		} else if err != nil {
 			return errors.WithMessage(err, "unpacking message")

--- a/pkg/backfill/map.go
+++ b/pkg/backfill/map.go
@@ -16,9 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/util/encoding"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
-	"git.liveramp.net/jgraet/factable/pkg/factable"
-	"git.liveramp.net/jgraet/factable/pkg/internal"
 )
 
 type cmdMap struct {


### PR DESCRIPTION
The `framing.Unpack` method usually wraps the `EOF` error when it returns. A wrapped or non-wrapped `EOF` will be honored in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/factable/6)
<!-- Reviewable:end -->
