### PR TITLE
bufio.ErrBufferFull fix

### DIFF
--- a/pkg/factable/kv_iterators.go
+++ b/pkg/factable/kv_iterators.go
@@ -354,23 +354,23 @@ func (h *hexIter) Next() ([]byte, []byte, error) {
 	}
 
 	// Read hex-encoded row value.
-	if raw, err = h.br.ReadSlice('\n'); err == io.EOF {
+	if raw, err = h.br.ReadSlice('\n'); err == nil {
+		// no-op - continue.
+	} else if err == io.EOF {
 		return nil, nil, io.ErrUnexpectedEOF
-	} else if err != nil {
-		if err == bufio.ErrBufferFull {
-			var rest, full []byte
-			// Preserve read contents.
-			full = append(full, raw...)
-			if rest, err = h.br.ReadBytes('\n'); err == io.EOF {
-				return nil, nil, io.ErrUnexpectedEOF
-			} else if err != nil {
-				return nil, nil, err
-			}
-			full = append(full, rest...)
-			raw = full
-		} else {
+	} else if err == bufio.ErrBufferFull {
+		var rest, full []byte
+		// Preserve read contents.
+		full = append(full, raw...)
+		if rest, err = h.br.ReadBytes('\n'); err == io.EOF {
+			return nil, nil, io.ErrUnexpectedEOF
+		} else if err != nil {
 			return nil, nil, err
 		}
+		full = append(full, rest...)
+		raw = full
+	} else {
+		return nil, nil, err
 	}
 
 	l = len(raw) - 1

--- a/pkg/factable/kv_iterators.go
+++ b/pkg/factable/kv_iterators.go
@@ -356,10 +356,21 @@ func (h *hexIter) Next() ([]byte, []byte, error) {
 	// Read hex-encoded row value.
 	if raw, err = h.br.ReadSlice('\n'); err == io.EOF {
 		return nil, nil, io.ErrUnexpectedEOF
-	} else if err == bufio.ErrBufferFull {
-
 	} else if err != nil {
-		return nil, nil, err
+		if err == bufio.ErrBufferFull {
+			var rest, full []byte
+			// Preserve read contents.
+			full = append(full, raw...)
+			if rest, err = h.br.ReadBytes('\n'); err == io.EOF {
+				return nil, nil, io.ErrUnexpectedEOF
+			} else if err != nil {
+				return nil, nil, err
+			}
+			full = append(full, rest...)
+			raw = full
+		} else {
+			return nil, nil, err
+		}
 	}
 
 	l = len(raw) - 1

--- a/pkg/factable/kv_iterators.go
+++ b/pkg/factable/kv_iterators.go
@@ -326,38 +326,18 @@ type hexIter struct {
 	key, val []byte
 }
 
-func bufferFullFallback(b *bufio.Reader, delim byte, orig []byte) ([]byte, error) {
-	var rest, full []byte
-	var err error
-	// Preserve read contents.
-	full = append(full, orig...)
-	if rest, err = b.ReadBytes(delim); err == io.EOF {
-		return nil, io.ErrUnexpectedEOF
-	} else if err != nil {
-		return nil, err
-	}
-	full = append(full, rest...)
-	return full, nil
-}
-
 func (h *hexIter) Next() ([]byte, []byte, error) {
 	var raw []byte
 	var err error
 
 	// Read hex-encoded row key.
-	if raw, err = h.br.ReadSlice('\t'); err == nil {
-		// no-op - continue.
-	} else if err == io.EOF {
+	if raw, err = readUntil(h.br, '\t'); err == io.EOF {
 		if len(raw) == 0 {
 			return nil, nil, KVIteratorDone
 		} else {
 			return nil, nil, io.ErrUnexpectedEOF
 		}
-	} else if err == bufio.ErrBufferFull {
-		if raw, err = bufferFullFallback(h.br, '\t', raw); err != nil {
-			return nil, nil, err
-		}
-	}  else {
+	} else if err != nil{
 		return nil, nil, err
 	}
 
@@ -374,15 +354,9 @@ func (h *hexIter) Next() ([]byte, []byte, error) {
 	}
 
 	// Read hex-encoded row value.
-	if raw, err = h.br.ReadSlice('\n'); err == nil {
-		// no-op - continue.
-	} else if err == io.EOF {
+	if raw, err = readUntil(h.br, '\n'); err == io.EOF {
 		return nil, nil, io.ErrUnexpectedEOF
-	} else if err == bufio.ErrBufferFull {
-		if raw, err = bufferFullFallback(h.br, '\n', raw); err != nil {
-			return nil, nil, err
-		}
-	} else {
+	} else if err != nil {
 		return nil, nil, err
 	}
 
@@ -417,6 +391,21 @@ func (e *HexEncoder) Encode(key, value []byte) error {
 	_ = e.bw.WriteByte('\t')
 	_, _ = e.hw.Write(value)
 	return e.bw.WriteByte('\n')
+}
+
+func readUntil(br *bufio.Reader, delim byte) ([]byte, error) {
+	var b, err = br.ReadSlice(delim)
+	if err == bufio.ErrBufferFull {
+		var full, rest []byte
+		// Preserve read contents as as the reader overwrites `b` in subsequent
+		// reads with contents of its internal buffer.
+		full = append(full, b...)
+
+		rest, err = br.ReadBytes(delim)
+		full = append(full, rest...)
+		b = full
+	}
+	return b, err
 }
 
 // NewStreamIterator returns a KVIterator which wraps a stream. |recvFn| reads

--- a/pkg/factable/kv_iterators.go
+++ b/pkg/factable/kv_iterators.go
@@ -356,6 +356,8 @@ func (h *hexIter) Next() ([]byte, []byte, error) {
 	// Read hex-encoded row value.
 	if raw, err = h.br.ReadSlice('\n'); err == io.EOF {
 		return nil, nil, io.ErrUnexpectedEOF
+	} else if err == bufio.ErrBufferFull {
+
 	} else if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/factable/kv_iterators.go
+++ b/pkg/factable/kv_iterators.go
@@ -397,7 +397,7 @@ func readUntil(br *bufio.Reader, delim byte) ([]byte, error) {
 	var b, err = br.ReadSlice(delim)
 	if err == bufio.ErrBufferFull {
 		var full, rest []byte
-		// Preserve read contents as as the reader overwrites `b` in subsequent
+		// Preserve read contents as the reader overwrites `b` in subsequent
 		// reads with contents of its internal buffer.
 		full = append(full, b...)
 

--- a/pkg/factable/kv_iterators_test.go
+++ b/pkg/factable/kv_iterators_test.go
@@ -275,6 +275,13 @@ func (s *IteratorsSuite) TestHexIteratorRoundTrip(c *gc.C) {
 	verify(c, it, NewSliceIterator(seq...), false, false)
 }
 
+func (s *IteratorsSuite) TextHexIteratorErrBufferFull (c *gc.C) {
+	var (
+		buf bytes.Buffer
+		bw = bufio.NewWriter(&buf)
+	)
+}
+
 func buildTestKeyValueSequence() (kvs [][2][]byte) {
 	var arena = make(kvsArena, 1<<12)
 	var value = encoding.EncodeVarintAscending(nil, 1)

--- a/pkg/factable/kv_iterators_test.go
+++ b/pkg/factable/kv_iterators_test.go
@@ -278,7 +278,7 @@ func (s *IteratorsSuite) TestHexIteratorRoundTrip(c *gc.C) {
 func (s *IteratorsSuite) TestHexIteratorBufferFull(c *gc.C) {
 	var (
 		buf bytes.Buffer
-		seq            = buildFatValueSequence()
+		seq            = buildOverflowSequences()
 		it  KVIterator = NewSliceIterator(seq...)
 		bw             = bufio.NewWriter(&buf)
 		hw             = NewHexEncoder(bw)
@@ -298,13 +298,21 @@ func (s *IteratorsSuite) TestHexIteratorBufferFull(c *gc.C) {
 	verify(c, it, NewSliceIterator(seq...), false, false)
 }
 
-func buildFatValueSequence() (kvs [][2][]byte) {
-	// value will fit into 16 byte buffer (including '\n' byte suffix).
-	var fit = [2][]byte{{0x01, 0x10}, {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}}
+func buildOverflowSequences() (kvs [][2][]byte) {
+	// key and value will fit into 16 byte buffer (including '\n' and '\t' byte suffixes).
+	var kvFit = [2][]byte{{0x01, 0x10}, {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}}
+	// key won't fit into 16 byte buffer.
+	var kNoFit = [2][]byte{{0x01, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18},
+		{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}}
 	// value won't fit into 16 byte buffer.
-	var noFit = [2][]byte{{0x01, 0x11}, {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}
-	kvs = append(kvs, fit)
-	kvs = append(kvs, noFit)
+	var vNoFit = [2][]byte{{0x01, 0x11}, {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}
+	// key and value wont fit into 16 byte buffer (including '\n' and '\t' byte suffixes).
+	var kvNoFit = [2][]byte{{0x01, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18},
+		{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}
+	kvs = append(kvs, kvFit)
+	kvs = append(kvs, kNoFit)
+	kvs = append(kvs, vNoFit)
+	kvs = append(kvs, kvNoFit)
 	return
 }
 


### PR DESCRIPTION
In cases where the contents of a key or value are too big for the bufio.Reader used in the hex iterator (32 KB in the case of combiner.go), then we want to fall back to reading the rest of the content in memory, using `bufio.Reader.ReadBytes` instead.

Added a unit test to ensure functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/factable/7)
<!-- Reviewable:end -->
