### PR TITLE
Add circleci support

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+ build:
+   machine: true
+   steps:
+     - checkout
+     # build the application image
+     - run: docker build -t liveramp/factable:$CIRCLE_BRANCH .


### PR DESCRIPTION
Add bare-bones Docker support for CircleCI.  All this does is builds the container and reports on whether or not that build was successful.