### PR TITLE
Add circleci support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2
+jobs:
+ build:
+   machine: true
+   steps:
+     - checkout
+     - run: docker build -t liveramp/factable:$CIRCLE_BRANCH .


### PR DESCRIPTION
Add bare-bones Docker support for CircleCI.  All this does is builds the container and reports on whether or not that build was successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/factable/12)
<!-- Reviewable:end -->
