### PR TITLE
Add quotes-backfill binary to support quickstart-console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM base as factable
 COPY --from=build \
     /go/bin/vtable \
     /go/bin/factctl \
+    /go/bin/quotes-backfill \
     /go/bin/quotes-extractor \
     /go/bin/quotes-publisher \
     /go/bin/


### PR DESCRIPTION
To provide backwards compatibility with the existing quickstart-console, add the `quotes-backfill` binary to the factable image.

This PR supports the quickstart-console Dockerfile PR [#2439](https://github.com/LiveRamp/publishers/pull/2439). 

Jira: [PX-1489](https://liveramp.atlassian.net/browse/PX-1489)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/factable/15)
<!-- Reviewable:end -->
